### PR TITLE
pass pulsar properties as header to webhook

### DIFF
--- a/src/broker/webhook.go
+++ b/src/broker/webhook.go
@@ -119,7 +119,7 @@ func toPulsar(r *http.Response) {
 		log.Printf("error missing required topic headers from webhook/function")
 		return
 	}
-	log.Printf("topicURL %s puslarURL %s", topicFN, pulsarURL)
+	log.Printf("topicURL %s pulsarURL %s", topicFN, pulsarURL)
 
 	b, err2 := ioutil.ReadAll(r.Body)
 	defer r.Body.Close()
@@ -168,8 +168,13 @@ func ConsumeLoop(url, token, topic, webhookURL, subscription string, headers []s
 		} else if msg != nil {
 			headers = append(headers, fmt.Sprintf("PulsarMessageId:%s", msg.ID()))
 			headers = append(headers, fmt.Sprintf("PulsarPublishedTime:%s", msg.PublishTime().String()))
-			headers = append(headers, fmt.Sprintf("PuslarTopic:%s", msg.Topic()))
-			headers = append(headers, fmt.Sprintf("PulsarEventTime:%s", msg.EventTime().String()))
+			headers = append(headers, fmt.Sprintf("PulsarTopic:%s", msg.Topic()))
+			if msg.EventTime() != nil {
+				headers = append(headers, fmt.Sprintf("PulsarEventTime:%s", msg.EventTime().String()))
+			}
+			for k, v := range msg.Properties() {
+				headers = append(headers, fmt.Sprintf("PulsarProperties%s:%s", k, v))
+			}
 
 			data := msg.Payload()
 			if json.Valid(data) {

--- a/src/broker/webhook.go
+++ b/src/broker/webhook.go
@@ -21,10 +21,6 @@ import (
 	"github.com/pulsar-beam/src/util"
 )
 
-// A webhook broker that reads configuration from a file
-// Definitely definitely we need a database to store the webhook configuration
-// This is a prototype only.
-
 // key is the hash of topic full name and pulsar url
 var webhooks = make(map[string]bool)
 var whLock = sync.RWMutex{}
@@ -173,7 +169,7 @@ func ConsumeLoop(url, token, topic, webhookURL, subscription string, headers []s
 				headers = append(headers, fmt.Sprintf("PulsarEventTime:%s", msg.EventTime().String()))
 			}
 			for k, v := range msg.Properties() {
-				headers = append(headers, fmt.Sprintf("PulsarProperties%s:%s", k, v))
+				headers = append(headers, fmt.Sprintf("PulsarProperties-%s:%s", k, v))
 			}
 
 			data := msg.Payload()
@@ -219,7 +215,7 @@ func run() {
 			cancelConsumer(k)
 		}
 	}
-	log.Println("load webhooks", len(webhooks))
+	log.Println("load webhooks size ", len(webhooks))
 }
 
 // LoadConfig loads the entire topic documents from the database

--- a/src/broker/webhook.go
+++ b/src/broker/webhook.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,11 +24,6 @@ import (
 // A webhook broker that reads configuration from a file
 // Definitely definitely we need a database to store the webhook configuration
 // This is a prototype only.
-
-// JSONData is the request body to the webhook interface
-type JSONData struct {
-	Data string
-}
 
 // key is the hash of topic full name and pulsar url
 var webhooks = make(map[string]bool)
@@ -84,21 +81,29 @@ func NewDbHandler() {
 }
 
 // pushWebhook sends data to a webhook interface
-func pushWebhook(url, data string) (int, *http.Response) {
+func pushWebhook(url string, data []byte, headers []string) (int, *http.Response) {
 
 	client := retryablehttp.NewClient()
 	client.RetryWaitMin = 2 * time.Second
 	client.RetryWaitMax = 28 * time.Second
 	client.RetryMax = 1
 
-	body, err2 := json.Marshal(JSONData{data})
-	if err2 != nil {
-		log.Printf("webhook data marshalling error %s", err2.Error())
-		return http.StatusUnprocessableEntity, nil
+	req, err := retryablehttp.NewRequest("POST", url, data)
+	if err != nil {
+		panic(err)
 	}
 
-	res, err := client.Post(url, "application/json", body)
+	for _, h := range headers {
+		// since : is allowed in header's value
+		l := strings.SplitAfterN(h, ":", 2)
+		if len(l) == 2 {
+			headerKey := strings.TrimSpace(strings.Replace(l[0], ":", "", -1))
+			req.Header.Set(headerKey, strings.TrimSpace(l[1]))
+		}
+		//discard any misformed headers
+	}
 
+	res, err := client.Do(req)
 	if err != nil {
 		log.Printf("webhook post error %s", err.Error())
 		return http.StatusInternalServerError, nil
@@ -129,8 +134,8 @@ func toPulsar(r *http.Response) {
 	}
 }
 
-func pushAndAck(c pulsar.Consumer, msg pulsar.Message, url, data string) {
-	code, res := pushWebhook(url, data)
+func pushAndAck(c pulsar.Consumer, msg pulsar.Message, url string, data []byte, headers []string) {
+	code, res := pushWebhook(url, data, headers)
 	if (code >= 200 && code < 300) || code == http.StatusUnprocessableEntity {
 		c.Ack(msg)
 
@@ -143,7 +148,7 @@ func pushAndAck(c pulsar.Consumer, msg pulsar.Message, url, data string) {
 
 // ConsumeLoop consumes data from Pulsar topic
 // Do not use context since go vet will puke that requires cancel invoked in the same function
-func ConsumeLoop(url, token, topic, webhookURL, subscription string) error {
+func ConsumeLoop(url, token, topic, webhookURL, subscription string, headers []string) error {
 	c := pulsardriver.GetConsumer(url, token, topic, subscription)
 	if c == nil {
 		return errors.New("Failed to create Pulsar consumer")
@@ -161,9 +166,16 @@ func ConsumeLoop(url, token, topic, webhookURL, subscription string) error {
 			log.Println("error from consumer loop receive")
 			log.Println(err)
 		} else if msg != nil {
-			data := string(msg.Payload())
-			log.Println("Received message : ", data)
-			pushAndAck(c, msg, webhookURL, data)
+			headers = append(headers, fmt.Sprintf("PulsarMessageId:%s", msg.ID()))
+			headers = append(headers, fmt.Sprintf("PulsarPublishedTime:%s", msg.PublishTime().String()))
+			headers = append(headers, fmt.Sprintf("PuslarTopic:%s", msg.Topic()))
+			headers = append(headers, fmt.Sprintf("PulsarEventTime:%s", msg.EventTime().String()))
+
+			data := msg.Payload()
+			if json.Valid(data) {
+				headers = append(headers, "content-type:application/json")
+			}
+			pushAndAck(c, msg, webhookURL, data, headers)
 		} else {
 			return nil
 		}
@@ -180,6 +192,7 @@ func run() {
 			token := cfg.Token
 			url := cfg.PulsarURL
 			webhookURL := whCfg.URL
+			webhookHeaders := whCfg.Headers
 			// ensure random subscription name
 			subscription := util.AssignString(whCfg.Subscription, icrypto.GenTopicKey())
 			status := whCfg.WebhookStatus
@@ -188,7 +201,7 @@ func run() {
 				subscriptionSet[subscription] = true
 				if !ok {
 					log.Printf("add activated webhook for topic subscription %v", subscription)
-					go ConsumeLoop(url, token, topic, webhookURL, subscription)
+					go ConsumeLoop(url, token, topic, webhookURL, subscription, webhookHeaders)
 				}
 			}
 		}

--- a/src/db/in-memory.go
+++ b/src/db/in-memory.go
@@ -64,7 +64,7 @@ func (s *InMemoryHandler) Create(topicCfg *model.TopicConfig) (string, error) {
 	return key, nil
 }
 
-// GetByTopic gets a document by the topic name and puslar URL
+// GetByTopic gets a document by the topic name and pulsar URL
 func (s *InMemoryHandler) GetByTopic(topicFullName, pulsarURL string) (*model.TopicConfig, error) {
 	key, err := model.GetKeyFromNames(topicFullName, pulsarURL)
 	if err != nil {

--- a/src/db/mongo.go
+++ b/src/db/mongo.go
@@ -112,7 +112,7 @@ func (s *MongoDb) Create(topicCfg *model.TopicConfig) (string, error) {
 	return topicCfg.Key, nil
 }
 
-// GetByTopic gets a document by the topic name and puslar URL
+// GetByTopic gets a document by the topic name and pulsar URL
 func (s *MongoDb) GetByTopic(topicFullName, pulsarURL string) (*model.TopicConfig, error) {
 	key, err := model.GetKeyFromNames(topicFullName, pulsarURL)
 	if err != nil {

--- a/src/db/pulsardb.go
+++ b/src/db/pulsardb.go
@@ -165,7 +165,7 @@ func (s *PulsarHandler) updateCacheAndPulsar(topicCfg *model.TopicConfig) (strin
 	return topicCfg.Key, nil
 }
 
-// GetByTopic gets a document by the topic name and puslar URL
+// GetByTopic gets a document by the topic name and pulsar URL
 func (s *PulsarHandler) GetByTopic(topicFullName, pulsarURL string) (*model.TopicConfig, error) {
 	key, err := model.GetKeyFromNames(topicFullName, pulsarURL)
 	if err != nil {

--- a/src/e2e/e2etest.go
+++ b/src/e2e/e2etest.go
@@ -121,7 +121,8 @@ func produceMessage() string {
 
 	beamReceiverURL := "http://localhost:3000/v1/firehose"
 	sentMessage := fmt.Sprintf("hello-from-e2e-test %d", time.Now().Unix())
-	originalData := []byte(sentMessage)
+	originalData := []byte(`{"Data": "` + sentMessage + `"}`)
+	log.Println(string(originalData))
 
 	//Send to Pulsar Beam
 	req, err := http.NewRequest("POST", beamReceiverURL, bytes.NewBuffer(originalData))

--- a/src/pulsardriver/client-driver.go
+++ b/src/pulsardriver/client-driver.go
@@ -79,10 +79,18 @@ func SendToPulsar(url, token, topic string, data []byte) error {
 
 	ctx := context.Background()
 
+	id, err := util.NewUUID()
+	if err != nil {
+		// this is very bad if happens
+		log.Printf("NewUUID generation error %v", err)
+		id = string(time.Now().Unix())
+	}
+	prop := map[string]string{"PulsarBeamId": id}
 	// Create a different message to send asynchronously
 	asyncMsg := pulsar.ProducerMessage{
-		Payload:   data,
-		EventTime: time.Now(),
+		Payload:    data,
+		EventTime:  time.Now(),
+		Properties: prop,
 	}
 
 	p.SendAsync(ctx, asyncMsg, func(msg pulsar.ProducerMessage, err error) {

--- a/src/pulsardriver/client-driver.go
+++ b/src/pulsardriver/client-driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"time"
 
 	"github.com/apache/pulsar/pulsar-client-go/pulsar"
 	"github.com/pulsar-beam/src/util"
@@ -80,7 +81,8 @@ func SendToPulsar(url, token, topic string, data []byte) error {
 
 	// Create a different message to send asynchronously
 	asyncMsg := pulsar.ProducerMessage{
-		Payload: data,
+		Payload:   data,
+		EventTime: time.Now(),
 	}
 
 	p.SendAsync(ctx, asyncMsg, func(msg pulsar.ProducerMessage, err error) {

--- a/src/route/handlers.go
+++ b/src/route/handlers.go
@@ -46,7 +46,7 @@ func ReceiveHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	log.Printf("topicFN %s puslarURL %s", topicFN, pulsarURL)
+	log.Printf("topicFN %s pulsarURL %s", topicFN, pulsarURL)
 
 	err = pulsardriver.SendToPulsar(pulsarURL, token, topicFN, b)
 	if err != nil {


### PR DESCRIPTION
* pass pulsar properties as header to webhook or cloud function
* pass Pulsar message as is in req.body no enrichment
* add Pulsar Beam Id in the pulsar message's properties
* enforce Pulsar event time in the message that received by the ingestion endpoint and replied from the webhook/cloud function