### PR TITLE
swagger doc generation and producer TTL cache

### DIFF
--- a/src/docs/api.go
+++ b/src/docs/api.go
@@ -1,0 +1,110 @@
+package docs
+
+import (
+	"github.com/kafkaesque-io/pulsar-beam/src/model"
+	"github.com/kafkaesque-io/pulsar-beam/src/util"
+)
+
+// swagger:route POST /v1/firehose Event-Receiver idOfFirehoseEndpoint
+// The endpoint receives a message in HTTP body that will be sent to Pulsar.
+//
+// headers:
+// responses:
+//   200:
+//   401: errorResponse
+//   500: errorResponse
+//   503: errorResponse
+
+// swagger:route GET /v2/topic Get-Topic idOfGetTopic
+// Get a topic configuration based on the topic name.
+//
+// headers:
+// responses:
+//   200: topicGetResponse
+//   403:
+//   404: errorResponse
+//   422: errorResponse
+//   500: errorResponse
+
+// swagger:route GET /v2/topic/{topicKey} Get-Topic idOfGetTopicKey
+// Get a topic configuration based on topic key.
+//
+// headers:
+// responses:
+//   200: topicGetResponse
+//   403:
+//   404: errorResponse
+//   422: errorResponse
+//   500: errorResponse
+
+// swagger:route POST /v2/topic Create-or-Update-Topic idOfUpdateTopic
+// Create or update a topic configuration.
+// Please do NOT specifiy key. The topic status must be for 1 for activation.
+//
+// responses:
+//   201: topicUpdateResponse
+//   403:
+//   409: errorResponse
+//   422: errorResponse
+//   500: errorResponse
+
+// swagger:route DELETE /v2/topic Delete-Topic idOfDeleteTopicKey
+// Delete a topic configuration based on topic name.
+//
+// headers:
+// responses:
+//   200: topicDeleteResponse
+//   403: errorResponse
+//   404: errorResponse
+//   422: errorResponse
+//   500: errorResponse
+
+// swagger:route DELETE /v2/topic/{topicKey} Delete-Topic idOfDeleteTopic
+// Delete a topic configuration based on topic key.
+//
+// headers:
+// responses:
+//   200: topicDeleteResponse
+//   403: errorResponse
+//   404: errorResponse
+//   422: errorResponse
+//   500: errorResponse
+
+// swagger:parameters idOfGetTopic
+type topicGetParams struct {
+	// in:body
+	Body model.TopicKey
+}
+
+// swagger:parameters idOfDeleteTopic
+type topicDeleteParams struct {
+	// in:body
+	Body model.TopicKey
+}
+
+// swagger:response topicGetResponse
+type topicGetResponse struct {
+	Body model.TopicConfig
+}
+
+// swagger:response topicDeleteResponse
+type topicDeleteResponse struct {
+	Body model.TopicConfig
+}
+
+// swagger:response topicUpdateResponse
+type topicUpdateResponse struct {
+	Body model.TopicConfig
+}
+
+// swagger:parameters idOfUpdateTopic
+type topicUpdateParams struct {
+	// in:body
+	Body model.TopicConfig
+}
+
+// swagger:response errorResponse
+type errorResponse struct {
+	// in:body
+	Body util.ResponseErr
+}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1,0 +1,29 @@
+// Package docs Pulsar Beam
+//
+// Documentation of Pulsar Beam API.
+//
+//     Schemes: http
+//     BasePath: /
+//     Version: 0.2.0
+//
+//     License: Apache 2.0 https://www.apache.org/licenses/LICENSE-2.0
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+//     Schemes:
+//     - https
+//
+//     Security:
+//       - bearerAuth: []
+//
+//    SecurityDefinitions:
+//    bearerAuth:
+//      type: bearer
+//      bearerFormat: JWT
+//
+// swagger:meta
+package docs

--- a/src/main.go
+++ b/src/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kafkaesque-io/pulsar-beam/src/util"
 	"github.com/rs/cors"
 	log "github.com/sirupsen/logrus"
+
+	_ "github.com/kafkaesque-io/pulsar-beam/src/docs" // This line is required for go-swagger to find docs
 )
 
 var mode = util.AssignString(os.Getenv("ProcessMode"), *flag.String("mode", "hybrid", "server running mode"))

--- a/src/pulsardriver/pulsar-producer.go
+++ b/src/pulsardriver/pulsar-producer.go
@@ -12,22 +12,17 @@ import (
 )
 
 // ProducerCache is the cache for Producer objects
-var ProducerCache *util.Cache
-
-// Init initializes Pulsar drivers such as Client, Consumer, and Producer cache
-func Init() {
-	ProducerCache = util.NewCache(util.CacheOption{
-		TTL:           900 * time.Second,
-		CleanInterval: 902 * time.Second,
-		ExpireCallback: func(key string, value interface{}) {
-			if obj, ok := value.(*PulsarProducer); ok {
-				obj.Close()
-			} else {
-				log.Errorf("wrong PulsrProducer object type stored in Cache")
-			}
-		},
-	})
-}
+var ProducerCache = util.NewCache(util.CacheOption{
+	TTL:           900 * time.Second,
+	CleanInterval: 902 * time.Second,
+	ExpireCallback: func(key string, value interface{}) {
+		if obj, ok := value.(*PulsarProducer); ok {
+			obj.Close()
+		} else {
+			log.Errorf("wrong PulsrProducer object type stored in Cache")
+		}
+	},
+})
 
 // GetPulsarProducer gets a Pulsar producer object
 func GetPulsarProducer(pulsarURL, pulsarToken, topic string) (pulsar.Producer, error) {

--- a/src/route/handlers.go
+++ b/src/route/handlers.go
@@ -3,6 +3,7 @@ package route
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -60,7 +61,7 @@ func ReceiveHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := ioutil.ReadAll(r.Body)
 	defer r.Body.Close()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		util.ResponseErrorJSON(err, w, http.StatusInternalServerError)
 		return
 	}
 
@@ -136,25 +137,25 @@ func UpdateTopicHandler(w http.ResponseWriter, r *http.Request) {
 
 	id, err := singleDb.Update(&doc)
 	if err != nil {
-		w.WriteHeader(http.StatusConflict)
+		util.ResponseErrorJSON(err, w, http.StatusConflict)
 		return
 	}
 	if len(id) > 1 {
 		savedDoc, err := singleDb.GetByKey(id)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			util.ResponseErrorJSON(err, w, http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
 		resJSON, err := json.Marshal(savedDoc)
 		if err != nil {
-			log.Errorf("marshal updated topic error %v", err)
+			util.ResponseErrorJSON(err, w, http.StatusInternalServerError)
 			return
 		}
 		w.Write(resJSON)
 		return
 	}
-	w.WriteHeader(http.StatusInternalServerError)
+	util.ResponseErrorJSON(fmt.Errorf("failed to update"), w, http.StatusInternalServerError)
 	return
 }
 
@@ -179,7 +180,7 @@ func DeleteTopicHandler(w http.ResponseWriter, r *http.Request) {
 
 	deletedKey, err := singleDb.DeleteByKey(topicKey)
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		util.ResponseErrorJSON(err, w, http.StatusNotFound)
 		return
 	}
 	resJSON, err := json.Marshal(deletedKey)

--- a/src/util/cache-item.go
+++ b/src/util/cache-item.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"time"
+)
+
+const (
+	// ItemNotExpire avoids the item being expired by TTL
+	ItemNotExpire time.Duration = -1
+)
+
+func newItem(key string, object interface{}, ttl time.Duration) *item {
+	item := &item{
+		data: object,
+		ttl:  ttl,
+		key:  key,
+	}
+	// no mutex is required for the first time
+	item.touch()
+	return item
+}
+
+type item struct {
+	key      string
+	data     interface{}
+	ttl      time.Duration
+	expireAt time.Time
+}
+
+// Reset the item expiration time
+func (item *item) touch() {
+	if item.ttl > 0 {
+		item.expireAt = time.Now().Add(item.ttl)
+	}
+}
+
+// Verify if the item is expired
+func (item *item) expired() bool {
+	if item.ttl <= 0 {
+		return false
+	}
+	return item.expireAt.Before(time.Now())
+}

--- a/src/util/ttlcache.go
+++ b/src/util/ttlcache.go
@@ -1,0 +1,135 @@
+package util
+
+import (
+	"sync"
+	"time"
+)
+
+// ExpireCallback is used as a callback on item expiration or when notifying of an item new to the cache
+type expireCallback func(key string, value interface{})
+
+// Cache is a synchronized map of items that can auto-expire once stale
+type Cache struct {
+	mutex          sync.RWMutex
+	opt            CacheOption
+	items          map[string]*item
+	shutdownSignal chan (chan struct{})
+	isShutDown     bool
+}
+
+// CacheOption is the optional configuration for Cache
+type CacheOption struct {
+	TTL            time.Duration
+	CleanInterval  time.Duration
+	ExpireCallback expireCallback
+}
+
+// Get gets an object from the cache
+func (c *Cache) Get(key string) (interface{}, bool) {
+	c.mutex.RLock()
+	item, exists := c.items[key]
+	c.mutex.RUnlock()
+	if !exists {
+		return nil, false
+	}
+
+	if item.expired() {
+		c.mutex.Lock()
+		c.opt.ExpireCallback(key, item.data)
+		delete(c.items, key)
+		c.mutex.Unlock()
+		return nil, false
+	}
+
+	// item has no expiration
+	if item.ttl < 0 {
+		return item.data, true
+	}
+
+	// update expiry time, puts back to the cache
+	item.touch()
+	c.mutex.Lock()
+	c.items[key] = item
+	c.mutex.Unlock()
+
+	return item.data, true
+}
+
+// eventLoop name is a disguise. I should convert the lock/unlock to an event loop
+func (c *Cache) eventLoop() {
+	for {
+		select {
+		case <-time.Tick(c.opt.CleanInterval):
+			// RLock is faster than Lock, performant improve to get a slice of keys first
+			c.mutex.RLock()
+			keys := make([]string, 0, len(c.items))
+			for k := range c.items {
+				keys = append(keys, k)
+			}
+			c.mutex.RUnlock()
+
+			// Lock on individual item scan to reduce the lock section
+			for _, keyValue := range keys {
+				c.mutex.Lock()
+				if item, ok := c.items[keyValue]; ok && item.expired() {
+					c.opt.ExpireCallback(keyValue, item.data)
+					delete(c.items, keyValue)
+				}
+				c.mutex.Unlock()
+			}
+		}
+	}
+}
+
+// Close is not implmented yet
+func (c *Cache) Close() {}
+
+// Set adds a new item with a gobally set TTL by the cache
+func (c *Cache) Set(key string, data interface{}) {
+	c.SetWithTTL(key, data, 0)
+}
+
+// SetWithTTL adds a new item with individual ttl
+func (c *Cache) SetWithTTL(key string, data interface{}, ttl time.Duration) {
+	if ttl == 0 {
+		ttl = c.opt.TTL
+	}
+	item := newItem(key, data, ttl)
+	c.mutex.Lock()
+	c.items[key] = item
+	c.mutex.Unlock()
+}
+
+// Delete deletes an item with the key specified
+func (c *Cache) Delete(key string) {
+	// deletion is an atomic operation therefore it must Write-mutex the entire seciton
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if item, ok := c.items[key]; ok {
+		c.opt.ExpireCallback(key, item.data)
+		delete(c.items, key)
+	}
+}
+
+// Count returns the number of items in the cache
+func (c *Cache) Count() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return len(c.items)
+}
+
+// NewCache is a helper to create instance of the Cache struct
+func NewCache(option CacheOption) *Cache {
+
+	shutdownChan := make(chan chan struct{})
+
+	cache := &Cache{
+		items:          make(map[string]*item),
+		opt:            option,
+		shutdownSignal: shutdownChan,
+		isShutDown:     false,
+	}
+	go cache.eventLoop()
+	return cache
+}


### PR DESCRIPTION
This is to create swagger documents. Package `docs`, its code generation go files, and a build script are created for this purpose.

This PR also implemented TTL based cache for Pulsar producer. Pulsar Consumer does not need to implement TTL based cache because user can de-register webhooks and its topic listener, therefore the subscription can be cancelled (already implemented)