### PR TITLE
HTTP SSE support and cert loader

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -104,6 +104,7 @@ jobs:
           PULSAR_URI: ${{ secrets.PULSAR_URI }}
           REST_DB_TABLE_TOPIC: ${{ secrets.REST_DB_TABLE_TOPIC }}
       - name: Upload Coverage
+        if: github.repository == 'kafkaesque-io/pulsar-beam'
         uses: codecov/codecov-action@v1.0.0
         with :
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 
 Beam is an http based streaming and queueing system backed up by Apache Pulsar.
 
-1. A message can be sent to Pulsar via an HTTP POST method as a producer.
-2. A message can be pushed to a webhook or Cloud Function for consumption.
-3. A webhook or Cloud Function receives a message, process it and reply another message, in a response body, back to another Pulsar topic via Pulsar Beam.
+- [x] A message can be sent to Pulsar via an HTTP POST method as a producer.
+- [x] A message can be pushed to a webhook or Cloud Function for consumption.
+- [x] A webhook or Cloud Function receives a message, process it and reply another message, in a response body, back to another Pulsar topic via Pulsar Beam.
+- [x] Messages can be streamed via HTTP Sever Sent Event, [SSE](https://www.html5rocks.com/en/tutorials/eventsource/basics/)
 
 Opening an issue and PR are welcomed! Please email `contact@kafkaesque.io` for any inquiry or demo.
 
@@ -23,6 +24,8 @@ Opening an issue and PR are welcomed! Please email `contact@kafkaesque.io` for a
 Immediately, Pulsar can be supported on Windows and any languages with HTTP support.
 
 2. It has a very small footprint with a 15MB docker image size.
+
+3. Supports HTTP SSE streaming
 
 ## Interface
 
@@ -34,10 +37,23 @@ This is the endpoint to `POST` a message to Pulsar.
 ```
 /v1/firehose
 ```
-These HTTP headers are required to map to Pulsar topic.
+These HTTP headers may be required to map to Pulsar topic.
 1. Authorization -> Bearer token as Pulsar token
 2. TopicFn -> a full name of Pulsar topic (with tenant/namespace/topic) is required
 3. PulsarUrl -> a fully qualified pulsar or pulsar+ssl URL where the message should be sent to. It is optional. The message will be sent to Pulsar URL specified under `PulsarBrokerURL` in the pulsar-beam.yml file if it is absent.
+
+### Endpoint to stream HTTP Server Sent Event
+This is the endpoint to `GET` messages from Pulsar as a consumer subscription
+```
+/v1/sse
+```
+These HTTP headers may be required to map to Pulsar topic.
+1. Authorization -> Bearer token as Pulsar token
+2. TopicFn -> a full name of Pulsar topic (with tenant/namespace/topic) is required
+3. PulsarUrl -> a fully qualified pulsar or pulsar+ssl URL where the message should be sent to. It is optional. The message will be sent to Pulsar URL specified under `PulsarBrokerURL` in the pulsar-beam.yml file if it is absent.
+4. SubscriptionType -> Supported type strings are `exclusive` as default, `shared`, and `failover`
+5. SubscriptionInitialPosition -> supported type are `latest` as default and `earliest`
+6. SubscriptionName -> the length must be 5 characters or longer. An auto-generated name will be provided in absence. Only the auto-generated subscription will be unsubscribed.
 
 ### Webhook registration
 Webhook registration is done via REST API backed by a database of your choice, such as MongoDB, in momery cache, and Pulsar itself. Yes, you can use a compacted Pulsar topic as a database table to perform CRUD. The configuration parameter is `"PbDbType": "inmemory",` in the `pulsar_beam.yml` file or the env variable `PbDbType`.

--- a/src/broker/sse-broker.go
+++ b/src/broker/sse-broker.go
@@ -5,27 +5,11 @@ import (
 	"github.com/kafkaesque-io/pulsar-beam/src/pulsardriver"
 )
 
-// SSEBroker is an SSE (Sever Sent Event) Broker holds open client connections,
-// listens for incoming events on its Notifier channel
-// and send message to all registered connections
-type SSEBroker struct {
-
-	// Events are pushed to this channel by the main events-gathering routine
-	Notifier chan []byte
-
-	// New client connections
-	newClients chan chan []byte
-
-	// Closed client connections
-	closingClients chan chan []byte
-
-	// Client connections registry
-	clients map[chan []byte]bool
-}
-
 const (
 	// SSEBrokerMaxSize the max size of the number of HTTP SSE session is supported
 	SSEBrokerMaxSize = 200
+
+	// TODO add counters and max limit for SSEBroker
 )
 
 // GetPulsarClientConsumer returns Puslar client and consumer interface objects

--- a/src/broker/sse-broker.go
+++ b/src/broker/sse-broker.go
@@ -1,0 +1,49 @@
+package broker
+
+import (
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/kafkaesque-io/pulsar-beam/src/pulsardriver"
+)
+
+// SSEBroker is an SSE (Sever Sent Event) Broker holds open client connections,
+// listens for incoming events on its Notifier channel
+// and send message to all registered connections
+type SSEBroker struct {
+
+	// Events are pushed to this channel by the main events-gathering routine
+	Notifier chan []byte
+
+	// New client connections
+	newClients chan chan []byte
+
+	// Closed client connections
+	closingClients chan chan []byte
+
+	// Client connections registry
+	clients map[chan []byte]bool
+}
+
+const (
+	// SSEBrokerMaxSize the max size of the number of HTTP SSE session is supported
+	SSEBrokerMaxSize = 200
+)
+
+// GetPulsarClientConsumer returns Puslar client and consumer interface objects
+func GetPulsarClientConsumer(url, token, topic, subscriptionName string, subType pulsar.SubscriptionType, subInitPos pulsar.SubscriptionInitialPosition) (pulsar.Client, pulsar.Consumer, error) {
+	client, err := pulsardriver.NewPulsarClient(url, token)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:                       topic,
+		SubscriptionName:            subscriptionName,
+		SubscriptionInitialPosition: subInitPos,
+		Type:                        subType,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, consumer, nil
+}

--- a/src/main.go
+++ b/src/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"net/http"
 	"os"
 
 	"github.com/kafkaesque-io/pulsar-beam/src/broker"
@@ -45,12 +44,7 @@ func main() {
 		port := util.AssignString(config.PORT, "8085")
 		certFile := util.GetConfig().CertFile
 		keyFile := util.GetConfig().KeyFile
-		if len(certFile) > 1 && len(keyFile) > 1 {
-			log.Infof("load certFile %s and keyFile %s\n", certFile, keyFile)
-			log.Fatal(http.ListenAndServeTLS(":"+port, certFile, keyFile, handler))
-		} else {
-			log.Fatal(http.ListenAndServe(":"+port, handler))
-		}
+		log.Fatal(util.ListenAndServeTLS(":"+port, certFile, keyFile, handler))
 	}
 
 	for util.IsBroker(&mode) {

--- a/src/route/routes.go
+++ b/src/route/routes.go
@@ -58,6 +58,13 @@ var ReceiverRoutes = Routes{
 		ReceiveHandler,
 		middleware.NoAuth,
 	},
+	Route{
+		"http-sse",
+		"GET",
+		"/v1/sse",
+		SSEHandler,
+		middleware.AuthHeaderRequired,
+	},
 }
 
 // RestRoutes definition

--- a/src/unit-test/util_test.go
+++ b/src/unit-test/util_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/kafkaesque-io/pulsar-beam/src/broker"
 	"github.com/kafkaesque-io/pulsar-beam/src/model"
 	"github.com/kafkaesque-io/pulsar-beam/src/route"
@@ -149,12 +150,23 @@ func TestReceiverHeader(t *testing.T) {
 	_, _, _, result := ReceiverHeader(strings.Split("", ","), &header)
 	assert(t, result != nil, "expected error because of missing TopicFn")
 
+	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
+	assert(t, result != nil, "expected error because of missing TopicFn")
+
 	header.Set("TopicFn", "http://target.net/route")
 	var token, webhook string
 	token, webhook, _, result = ReceiverHeader(strings.Split("", ","), &header)
 	errNil(t, result)
 	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
 	assert(t, token == "", "test all headers presence")
+
+	token, webhook, _, subName, pos, subType, result := ClientConsumerHeader(strings.Split("", ","), &header)
+	errNil(t, result)
+	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
+	assert(t, token == "", "test all headers presence")
+	assert(t, len(subName) == 36, "default subName is UUID")
+	assert(t, pos == pulsar.SubscriptionPositionLatest, "default SubscriptionPositionLatest")
+	assert(t, subType == pulsar.Exclusive, "default subscription type is exclusive")
 
 	header.Set("Authorization", "Bearer erfagagagag")
 
@@ -173,6 +185,37 @@ func TestReceiverHeader(t *testing.T) {
 	assert(t, webhook == header.Get("TopicFn"), "pulsarURL in header matches one of allowed pulsar Cluster URLs")
 }
 
+func TestClientConsumerHeader(t *testing.T) {
+	header := http.Header{}
+	header.Set("PulsarUrl", "pulsar://mydomain.net:6650")
+	header.Set("TopicFn", "persistent://target.net/route")
+	header.Set("SubscriptionName", "12345")
+	header.Set("SubscriptionType", "shared")
+	header.Set("SubscriptionInitialPosition", "earliest")
+	_, _, _, subName, pos, subType, result := ClientConsumerHeader(strings.Split("", ","), &header)
+	errNil(t, result)
+	assert(t, subName == "12345", "match subscription name")
+	assert(t, pos == pulsar.SubscriptionPositionEarliest, "match subscription initial position")
+	assert(t, subType == pulsar.Shared, "match subscription type")
+
+	header.Set("SubscriptionType", "execlusive")
+	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
+	assert(t, strings.HasPrefix(result.Error(), "unsupported subscription type"), "unsupported subscription type")
+
+	header.Set("SubscriptionType", "exclusive")
+	header.Set("SubscriptionInitialPosition", "lastest")
+	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
+	assert(t, strings.HasPrefix(result.Error(), "invalid subscription initial position"), "invalid subscription initial position")
+
+	header.Set("SubscriptionInitialPosition", "latest")
+	header.Set("SubscriptionName", "1234")
+	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
+	assert(t, strings.HasPrefix(result.Error(), "subscription name must be more than 4 characters"), "subscription name must be more than 4 characters")
+
+	header.Set("SubscriptionName", "")
+	_, _, _, subName, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
+	assert(t, len(subName) == 36, "validate the length of subscription name is UUID length")
+}
 func TestDefaultPulsarURLInReceiverHeader(t *testing.T) {
 	allowedPulsarURLs := strings.Split("pulsar+ssl://kafkaesque.net:6651", ",")
 	header := http.Header{}

--- a/src/unit-test/util_test.go
+++ b/src/unit-test/util_test.go
@@ -164,7 +164,7 @@ func TestReceiverHeader(t *testing.T) {
 	errNil(t, result)
 	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
 	assert(t, token == "", "test all headers presence")
-	assert(t, len(subName)+len(model.NonResumable) == 36, "default subName is UUID")
+	assert(t, len(subName) == len(model.NonResumable)+36, "default subName is UUID")
 	assert(t, pos == pulsar.SubscriptionPositionLatest, "default SubscriptionPositionLatest")
 	assert(t, subType == pulsar.Exclusive, "default subscription type is exclusive")
 
@@ -214,7 +214,7 @@ func TestClientConsumerHeader(t *testing.T) {
 
 	header.Set("SubscriptionName", "")
 	_, _, _, subName, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, len(subName)+len(model.NonResumable) == 36, "validate the length of subscription name is UUID length")
+	assert(t, len(subName) == len(model.NonResumable)+36, "validate the length of subscription name is UUID length")
 }
 func TestDefaultPulsarURLInReceiverHeader(t *testing.T) {
 	allowedPulsarURLs := strings.Split("pulsar+ssl://kafkaesque.net:6651", ",")

--- a/src/unit-test/util_test.go
+++ b/src/unit-test/util_test.go
@@ -164,7 +164,7 @@ func TestReceiverHeader(t *testing.T) {
 	errNil(t, result)
 	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
 	assert(t, token == "", "test all headers presence")
-	assert(t, len(subName) == 36, "default subName is UUID")
+	assert(t, len(subName)+len(model.NonResumable) == 36, "default subName is UUID")
 	assert(t, pos == pulsar.SubscriptionPositionLatest, "default SubscriptionPositionLatest")
 	assert(t, subType == pulsar.Exclusive, "default subscription type is exclusive")
 
@@ -214,7 +214,7 @@ func TestClientConsumerHeader(t *testing.T) {
 
 	header.Set("SubscriptionName", "")
 	_, _, _, subName, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, len(subName) == 36, "validate the length of subscription name is UUID length")
+	assert(t, len(subName)+len(model.NonResumable) == 36, "validate the length of subscription name is UUID length")
 }
 func TestDefaultPulsarURLInReceiverHeader(t *testing.T) {
 	allowedPulsarURLs := strings.Split("pulsar+ssl://kafkaesque.net:6651", ",")

--- a/src/util/cert-loader.go
+++ b/src/util/cert-loader.go
@@ -1,0 +1,122 @@
+package util
+
+// This is a TLS certificate loader that detects the change of key and cert.
+// One use case is to reload letsencrypt certificates
+// Example to generate test certificate and key files
+// openssl req -newkey rsa:2048 -nodes -keyout domain.key -x509 -days 365 -out domain.crt
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+var cert atomic.Value
+
+type updatedChann struct{}
+
+func loadCert(certFile, keyFile string) error {
+	c, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		log.Printf("failed to LoadX509KeyPair %v", err)
+		return err
+	}
+
+	log.Println("successfully load certs and keys")
+	cert.Store(c)
+	return nil
+}
+
+type fileState struct {
+	info os.FileInfo
+	err  error
+}
+
+func watchFile(filePath string, updated chan *updatedChann) error {
+	initialStat, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-time.Tick(1 * time.Second):
+			stat, err := os.Stat(filePath)
+			if err == nil {
+				if stat.Size() != initialStat.Size() || stat.ModTime() != initialStat.ModTime() {
+					initialStat = stat
+					updated <- &updatedChann{}
+				}
+			}
+		}
+	}
+}
+
+// ListenAndServeTLS listens HTTP with TLS option just like the default http.ListenAndServeTLS
+// in addition it also watches certificate and key file changes and reloads them if necessary
+func ListenAndServeTLS(address, certFile, keyFile string, handler http.Handler) error {
+	if len(certFile) > 1 && len(keyFile) > 1 {
+		return listenAndServeTLS(address, certFile, keyFile, handler)
+	}
+	return http.ListenAndServe(address, handler)
+}
+
+func listenAndServeTLS(address, certFile, keyFile string, handler http.Handler) error {
+	log.Printf("load certs %s and key files %s\n", certFile, keyFile)
+	if err := loadCert(certFile, keyFile); err != nil {
+		return err
+	}
+
+	go func(cert, key string) {
+		certMonitorChan := make(chan *updatedChann, 1)
+		keyMonitorChan := make(chan *updatedChann, 1)
+
+		go watchFile(certFile, certMonitorChan)
+		go watchFile(keyFile, keyMonitorChan)
+
+		var certUpdated, keyUpdated bool
+		// only update X509 key pair when both cert and key files are updated
+		for {
+			select {
+			case <-certMonitorChan:
+				certUpdated = true
+				if certUpdated == keyUpdated {
+					certUpdated = false
+					keyUpdated = false
+					loadCert(certFile, keyFile)
+				}
+			case <-keyMonitorChan:
+				keyUpdated = true
+				if certUpdated == keyUpdated {
+					certUpdated = false
+					keyUpdated = false
+					loadCert(certFile, keyFile)
+				}
+			}
+		}
+	}(certFile, keyFile)
+	// Create tlsConfig that uses a custom GetCertificate method
+	// Defined by GetCertificate func at  https://golang.org/pkg/crypto/tls/
+	tlsConfig := tls.Config{
+		GetCertificate: func(i *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			c, ok := cert.Load().(tls.Certificate)
+			if !ok {
+				return nil, fmt.Errorf("Unable to load cert: %+v", c)
+			}
+
+			return &c, nil
+		},
+	}
+
+	// listen on the port with TLS listener
+	l, err := tls.Listen("tcp", address, &tlsConfig)
+	if err != nil {
+		return err
+	}
+
+	return http.Serve(l, handler)
+}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/kafkaesque-io/pulsar-beam/src/model"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -73,6 +75,46 @@ func ReceiverHeader(allowedClusters []string, h *http.Header) (token, topicFN, p
 	}
 	return token, topicFN, pulsarURL, nil
 
+}
+
+// ConsumerHeader returns a configuration parameters for Pulsar consumer
+func ConsumerHeader(h *http.Header) (subName string, subInitPos pulsar.SubscriptionInitialPosition, subType pulsar.SubscriptionType, err error) {
+
+	subType, err = model.GetSubscriptionType(h.Get("SubscriptionType"))
+	if err != nil {
+		return "", -1, -1, err
+	}
+	subInitPos, err = model.GetInitialPosition(h.Get("SubscriptionInitialPosition"))
+	if err != nil {
+		return "", -1, -1, err
+	}
+
+	subName = h.Get("SubscriptionName")
+	if len(subName) == 0 {
+		name, err := NewUUID()
+		if err != nil {
+			return "", -1, -1, fmt.Errorf("failed to generate uuid error %v", err)
+		}
+		return model.NonResumable + name, subInitPos, subType, nil
+	} else if len(subName) < 5 {
+		return "", -1, -1, fmt.Errorf("subscription name must be more than 4 characters")
+	}
+	return subName, subInitPos, subType, nil
+}
+
+// ClientConsumerHeader returns configuration parameters required to generate Pulsar Client and Consumer
+func ClientConsumerHeader(allowedClusters []string, h *http.Header) (token, topicFN, pulsarURL, subName string, subInitPos pulsar.SubscriptionInitialPosition, subType pulsar.SubscriptionType, err error) {
+	token, topicFN, pulsarURL, err = ReceiverHeader(allowedClusters, h)
+	if err != nil {
+		return "", "", "", "", -1, -1, err
+	}
+
+	subName, subInitPos, subType, err = ConsumerHeader(h)
+	if err != nil {
+		return "", "", "", "", -1, -1, err
+	}
+
+	return token, topicFN, pulsarURL, subName, subInitPos, subType, nil
 }
 
 // AssignString returns the first non-empty string


### PR DESCRIPTION
- Support HTTP SSE server sent event that allows an HTTP client receives messages just like a Pulsar consumer subscription
- Implement a customized certificate and key loader
- Monitor certificate and key changes
- Update them when both are changed
- Only enable codecov upload when it is run from this repo under kafkaesque-io organization, so that it will run against forked PR.