### PR TITLE
v2 firehose and sse route

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,29 @@ REST API and endpoint swagger document is published at [this link](https://kafka
 This is the endpoint to `POST` a message to Pulsar. 
 
 ```
-/v1/firehose
+/v2/firehose/{persistent}/{tenant}/{namespace}/{topic}
 ```
+Valid values of {persistent} are `p`, `persistent`, `np`, `nonpersistent`
+
 These HTTP headers may be required to map to Pulsar topic.
 1. Authorization -> Bearer token as Pulsar token
-2. TopicFn -> a full name of Pulsar topic (with tenant/namespace/topic) is required
-3. PulsarUrl -> a fully qualified pulsar or pulsar+ssl URL where the message should be sent to. It is optional. The message will be sent to Pulsar URL specified under `PulsarBrokerURL` in the pulsar-beam.yml file if it is absent.
+2. PulsarUrl -> *optional* a fully qualified pulsar or pulsar+ssl URL where the message should be sent to. It is optional. The message will be sent to Pulsar URL specified under `PulsarBrokerURL` in the pulsar-beam.yml file if it is absent.
 
 ### Endpoint to stream HTTP Server Sent Event
 This is the endpoint to `GET` messages from Pulsar as a consumer subscription
 ```
-/v1/sse
+/v2/sse/{persistent}/{tenant}/{namespace}/{topic}
 ```
+Valid values of {persistent} are `p`, `persistent`, `np`, `nonpersistent`
+
 These HTTP headers may be required to map to Pulsar topic.
 1. Authorization -> Bearer token as Pulsar token
-2. TopicFn -> a full name of Pulsar topic (with tenant/namespace/topic) is required
-3. PulsarUrl -> a fully qualified pulsar or pulsar+ssl URL where the message should be sent to. It is optional. The message will be sent to Pulsar URL specified under `PulsarBrokerURL` in the pulsar-beam.yml file if it is absent.
-4. SubscriptionType -> Supported type strings are `exclusive` as default, `shared`, and `failover`
-5. SubscriptionInitialPosition -> supported type are `latest` as default and `earliest`
-6. SubscriptionName -> the length must be 5 characters or longer. An auto-generated name will be provided in absence. Only the auto-generated subscription will be unsubscribed.
+2. PulsarUrl -> *optional* a fully qualified pulsar or pulsar+ssl URL where the message should be sent to. It is optional. The message will be sent to Pulsar URL specified under `PulsarBrokerURL` in the pulsar-beam.yml file if it is absent.
+
+Query parameters
+1. SubscriptionType -> Supported type strings are `exclusive` as default, `shared`, and `failover`
+2. SubscriptionInitialPosition -> supported type are `latest` as default and `earliest`
+3. SubscriptionName -> the length must be 5 characters or longer. An auto-generated name will be provided in absence. Only the auto-generated subscription will be unsubscribed.
 
 ### Webhook registration
 Webhook registration is done via REST API backed by a database of your choice, such as MongoDB, in momery cache, and Pulsar itself. Yes, you can use a compacted Pulsar topic as a database table to perform CRUD. The configuration parameter is `"PbDbType": "inmemory",` in the `pulsar_beam.yml` file or the env variable `PbDbType`.

--- a/src/route/handlers.go
+++ b/src/route/handlers.go
@@ -142,6 +142,9 @@ func SSEHandler(w http.ResponseWriter, r *http.Request) {
 		case msg := <-consumChan:
 			// log.Infof("received message %s on topic %s", string(msg.Payload()), topicFN)
 			consumer.Ack(msg)
+
+			// ledgerId, entryId, batchId, partitionIndex, reserved, consumerId
+			fmt.Fprintf(w, strings.Replace(fmt.Sprintf("id: %v\n", msg.Message.ID()), "&", "", 1))
 			fmt.Fprintf(w, "data: %s\n\n", msg.Payload())
 			flusher.Flush()
 		case <-r.Context().Done():

--- a/src/route/routes.go
+++ b/src/route/routes.go
@@ -59,11 +59,18 @@ var ReceiverRoutes = Routes{
 		middleware.NoAuth,
 	},
 	Route{
+		"Receive",
+		"POST",
+		"/v2/firehose/{persistent}/{tenant}/{namespace}/{topic}",
+		ReceiveHandler,
+		middleware.AuthVerifyJWT,
+	},
+	Route{
 		"http-sse",
 		"GET",
-		"/v1/sse",
+		"/v2/sse/{persistent}/{tenant}/{namespace}/{topic}",
 		SSEHandler,
-		middleware.AuthHeaderRequired,
+		middleware.AuthVerifyJWT,
 	},
 }
 

--- a/src/unit-test/handlers_test.go
+++ b/src/unit-test/handlers_test.go
@@ -319,3 +319,76 @@ func TestTopicModelFunctions(t *testing.T) {
 	})
 	errNil(t, err)
 }
+
+func TestGetTopicFullNameFromRoute(t *testing.T) {
+	vars := map[string]string{"tenant": "public", "namespace": "default", "topic": "testtopic", "persistent": "np"}
+	topicFn, err := GetTopicFnFromRoute(vars)
+	errNil(t, err)
+	assert(t, topicFn == "non-persistent://public/default/testtopic", "")
+
+	vars = map[string]string{"tenant": "public", "namespace": "default", "topic": "testtopic", "persistent": "persistent"}
+	topicFn, err = GetTopicFnFromRoute(vars)
+	errNil(t, err)
+	assert(t, topicFn == "persistent://public/default/testtopic", "")
+
+	vars = map[string]string{"tenant": "public", "namespace": "default", "topic": "testtopic", "persisten": "np"}
+	topicFn, err = GetTopicFnFromRoute(vars)
+	assert(t, err.Error() == "missing topic parts", "")
+
+	vars = map[string]string{"tenant": "public", "namespace": "default", "topic": "testtopic", "persistent": "nonpartition"}
+	topicFn, err = GetTopicFnFromRoute(vars)
+	assert(t, err.Error() == "supported persistent types are persistent, p, non-persistent, np", "")
+}
+
+func TestConsumerParams(t *testing.T) {
+	params := map[string][]string{"SubscriptionType": []string{"test"}}
+	_, _, _, err := ConsumerParams(params)
+	equals(t, err.Error(), "unsupported subscription type test")
+
+	params = map[string][]string{"SubscriptionType": []string{"shared"}}
+	subName, subPos, subType, err := ConsumerParams(params)
+	equals(t, subPos, pulsar.SubscriptionPositionLatest)
+	equals(t, subType, pulsar.Shared)
+	assert(t, strings.HasPrefix(subName, model.NonResumable), "")
+
+	params = map[string][]string{"SubscriptionInitialPosition": []string{"last"}}
+	_, _, _, err = ConsumerParams(params)
+	equals(t, err.Error(), "invalid subscription initial position last")
+
+	params = map[string][]string{"SubscriptionInitialPosition": []string{"earliest"}}
+	subName, subPos, subType, err = ConsumerParams(params)
+	equals(t, subPos, pulsar.SubscriptionPositionEarliest)
+	equals(t, subType, pulsar.Exclusive)
+	assert(t, strings.HasPrefix(subName, model.NonResumable), "")
+
+	params = map[string][]string{"SubscriptionName": []string{"last"}}
+	_, _, _, err = ConsumerParams(params)
+	equals(t, err.Error(), "subscription name must be more than 4 characters")
+
+	params = map[string][]string{"SubscriptionInitialPosition": []string{"earliest"}, "SubscriptionName": []string{"subname1234"}}
+	subName, subPos, subType, err = ConsumerParams(params)
+	equals(t, subPos, pulsar.SubscriptionPositionEarliest)
+	equals(t, subType, pulsar.Exclusive)
+	equals(t, subName, "subname1234")
+}
+
+func TestConsumerConfigFromHTTPParts(t *testing.T) {
+	params := map[string][]string{"SubscriptionInitialPosition": []string{"earliest"}, "SubscriptionName": []string{"subname1234"}}
+	vars := map[string]string{"tenant": "public", "namespace": "default", "topic": "testtopic", "persistent": "nonpartition"}
+	header := http.Header{}
+	// header.Set("Authorization", "Bearer erfagagagag")
+	header.Set("PulsarUrl", "pulsar://mydomain.net:6650")
+	_, _, _, _, _, _, err := ConsumerConfigFromHTTPParts(strings.Split("pulsar://mydomain.net:6651", ","), &header, vars, params)
+	equals(t, err.Error(), "pulsar cluster pulsar://mydomain.net:6650 is not allowed")
+	_, _, _, _, _, _, err = ConsumerConfigFromHTTPParts(strings.Split("", ","), &header, vars, params)
+	equals(t, err.Error(), "supported persistent types are persistent, p, non-persistent, np")
+
+	vars = map[string]string{"tenant": "public", "namespace": "default", "topic": "testtopic", "persistent": "p"}
+	params = map[string][]string{"SubscriptionInitialPosition": []string{"earlies"}, "SubscriptionName": []string{"subname1234"}}
+	_, _, _, _, _, _, err = ConsumerConfigFromHTTPParts(strings.Split("", ","), &header, vars, params)
+	equals(t, err.Error(), "invalid subscription initial position earlies")
+
+	params = map[string][]string{"SubscriptionInitialPosition": []string{"earliest"}, "SubscriptionName": []string{"subname1234"}}
+	_, _, _, _, _, _, err = ConsumerConfigFromHTTPParts(strings.Split("", ","), &header, vars, params)
+	errNil(t, err)
+}

--- a/src/unit-test/handlers_test.go
+++ b/src/unit-test/handlers_test.go
@@ -201,6 +201,23 @@ func TestFireHoseReceiverHandler(t *testing.T) {
 	equals(t, http.StatusUnauthorized, rr.Code)
 }
 
+func TestFireHoseV2ReceiverHandler(t *testing.T) {
+
+	req, err := http.NewRequest(http.MethodPost, "/v2/firehose", bytes.NewReader([]byte{}))
+	errNil(t, err)
+
+	rr := httptest.NewRecorder()
+	req.Header.Set("Authorization", "application/json")
+	req.Header.Set("PulsarUrl", "picasso")
+
+	req = mux.SetURLVars(req, map[string]string{"persistent": "persi", "tenant": "tenant", "namespace": "ns", "topic": "tc"})
+
+	handler := http.HandlerFunc(ReceiveHandler)
+
+	handler.ServeHTTP(rr, req)
+	equals(t, http.StatusUnprocessableEntity, rr.Code)
+}
+
 func TestSubjectMatch(t *testing.T) {
 	assert(t, !VerifySubjectBasedOnTopic("picasso", "picasso", ExtractEvalTenant), "")
 	assert(t, VerifySubjectBasedOnTopic("persistent://picasso/local-useast1-gcp", "picasso", ExtractEvalTenant), "")

--- a/src/unit-test/test_util.go
+++ b/src/unit-test/test_util.go
@@ -12,7 +12,7 @@ import (
 func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 	if !condition {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		fmt.Printf("[%s:%d: "+msg+"]\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
 		tb.FailNow()
 	}
 }
@@ -21,7 +21,7 @@ func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 func errNil(tb testing.TB, err error) {
 	if err != nil {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		fmt.Printf("[%s:%d: unexpected error: %s]\n\n", filepath.Base(file), line, err.Error())
 		tb.FailNow()
 	}
 }
@@ -30,7 +30,7 @@ func errNil(tb testing.TB, err error) {
 func assertErr(tb testing.TB, exp string, err error) {
 	if err == nil {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: error is expected.\033[39m\n\n", filepath.Base(file), line)
+		fmt.Printf("[%s:%d: error is expected.]\n\n", filepath.Base(file), line)
 		tb.FailNow()
 	} else {
 		equals(tb, exp, err.Error())

--- a/src/unit-test/util_test.go
+++ b/src/unit-test/util_test.go
@@ -145,15 +145,13 @@ func TestMainControlMode(t *testing.T) {
 func TestReceiverHeader(t *testing.T) {
 	header := http.Header{}
 	// header.Set("Authorization", "Bearer erfagagagag")
-	header.Set("PulsarUrl", "pulsar://mydomain.net:6650")
 	_, _, _, result := ReceiverHeader(strings.Split("", ","), &header)
-	assert(t, result != nil, "expected error because of missing TopicFn")
+	equals(t, result.Error(), "missing configured Pulsar URL")
 
-	header.Set("TopicFn", "http://target.net/route")
-	var token, webhook string
-	token, webhook, _, result = ReceiverHeader(strings.Split("", ","), &header)
+	header.Set("PulsarUrl", "http://target.net/route")
+	var token string
+	token, _, _, result = ReceiverHeader(strings.Split("", ","), &header)
 	errNil(t, result)
-	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
 	assert(t, token == "", "test all headers presence")
 }
 

--- a/src/unit-test/util_test.go
+++ b/src/unit-test/util_test.go
@@ -159,12 +159,13 @@ func TestDefaultPulsarURLInReceiverHeader(t *testing.T) {
 	allowedPulsarURLs := strings.Split("pulsar+ssl://kafkaesque.net:6651", ",")
 	header := http.Header{}
 	header.Set("Authorization", "Bearer erfagagagag")
-	_, _, _, result := ReceiverHeader(allowedPulsarURLs, &header)
-	assert(t, result != nil, "expected error because of missing TopicFn")
+	_, _, pulsarURL, result := ReceiverHeader(allowedPulsarURLs, &header)
+	errNil(t, result)
+	equals(t, pulsarURL, "pulsar+ssl://kafkaesque.net:6651")
 
 	header.Set("TopicFn", "http://target.net/route")
 	var webhook string
-	_, webhook, pulsarURL, result := ReceiverHeader(allowedPulsarURLs, &header)
+	_, webhook, pulsarURL, result = ReceiverHeader(allowedPulsarURLs, &header)
 	errNil(t, result)
 	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
 	assert(t, pulsarURL == "pulsar+ssl://kafkaesque.net:6651", "test all headers presence")

--- a/src/unit-test/util_test.go
+++ b/src/unit-test/util_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/kafkaesque-io/pulsar-beam/src/broker"
 	"github.com/kafkaesque-io/pulsar-beam/src/model"
 	"github.com/kafkaesque-io/pulsar-beam/src/route"
@@ -150,72 +149,14 @@ func TestReceiverHeader(t *testing.T) {
 	_, _, _, result := ReceiverHeader(strings.Split("", ","), &header)
 	assert(t, result != nil, "expected error because of missing TopicFn")
 
-	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, result != nil, "expected error because of missing TopicFn")
-
 	header.Set("TopicFn", "http://target.net/route")
 	var token, webhook string
 	token, webhook, _, result = ReceiverHeader(strings.Split("", ","), &header)
 	errNil(t, result)
 	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
 	assert(t, token == "", "test all headers presence")
-
-	token, webhook, _, subName, pos, subType, result := ClientConsumerHeader(strings.Split("", ","), &header)
-	errNil(t, result)
-	assert(t, webhook == header.Get("TopicFn"), "test all headers presence")
-	assert(t, token == "", "test all headers presence")
-	assert(t, len(subName) == len(model.NonResumable)+36, "default subName is UUID")
-	assert(t, pos == pulsar.SubscriptionPositionLatest, "default SubscriptionPositionLatest")
-	assert(t, subType == pulsar.Exclusive, "default subscription type is exclusive")
-
-	header.Set("Authorization", "Bearer erfagagagag")
-
-	allowedPulsarURLs := strings.Split("pulsar://mydomain.net:6650", ",")
-	_, webhook, _, result = ReceiverHeader(allowedPulsarURLs, &header)
-	errNil(t, result)
-	assert(t, webhook == header.Get("TopicFn"), "pulsarURL in header matches allowed pulsar Cluster URL")
-
-	allowedPulsarURLs = strings.Split("pulsar://kafkaesque.net:6650,", ",")
-	_, _, _, result = ReceiverHeader(allowedPulsarURLs, &header)
-	assert(t, result != nil, "pulsarURL in header does not match allowed pulsar Cluster URL")
-
-	allowedPulsarURLs = strings.Split("pulsar://kafkaesque.net:6650, pulsar://mydomain.net:6650", ",")
-	_, webhook, _, result = ReceiverHeader(allowedPulsarURLs, &header)
-	errNil(t, result)
-	assert(t, webhook == header.Get("TopicFn"), "pulsarURL in header matches one of allowed pulsar Cluster URLs")
 }
 
-func TestClientConsumerHeader(t *testing.T) {
-	header := http.Header{}
-	header.Set("PulsarUrl", "pulsar://mydomain.net:6650")
-	header.Set("TopicFn", "persistent://target.net/route")
-	header.Set("SubscriptionName", "12345")
-	header.Set("SubscriptionType", "shared")
-	header.Set("SubscriptionInitialPosition", "earliest")
-	_, _, _, subName, pos, subType, result := ClientConsumerHeader(strings.Split("", ","), &header)
-	errNil(t, result)
-	assert(t, subName == "12345", "match subscription name")
-	assert(t, pos == pulsar.SubscriptionPositionEarliest, "match subscription initial position")
-	assert(t, subType == pulsar.Shared, "match subscription type")
-
-	header.Set("SubscriptionType", "execlusive")
-	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, strings.HasPrefix(result.Error(), "unsupported subscription type"), "unsupported subscription type")
-
-	header.Set("SubscriptionType", "exclusive")
-	header.Set("SubscriptionInitialPosition", "lastest")
-	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, strings.HasPrefix(result.Error(), "invalid subscription initial position"), "invalid subscription initial position")
-
-	header.Set("SubscriptionInitialPosition", "latest")
-	header.Set("SubscriptionName", "1234")
-	_, _, _, _, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, strings.HasPrefix(result.Error(), "subscription name must be more than 4 characters"), "subscription name must be more than 4 characters")
-
-	header.Set("SubscriptionName", "")
-	_, _, _, subName, _, _, result = ClientConsumerHeader(strings.Split("", ","), &header)
-	assert(t, len(subName) == len(model.NonResumable)+36, "validate the length of subscription name is UUID length")
-}
 func TestDefaultPulsarURLInReceiverHeader(t *testing.T) {
 	allowedPulsarURLs := strings.Split("pulsar+ssl://kafkaesque.net:6651", ",")
 	header := http.Header{}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
 
-	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/kafkaesque-io/pulsar-beam/src/model"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -70,51 +69,18 @@ func ReceiverHeader(allowedClusters []string, h *http.Header) (token, topicFN, p
 			return "", "", "", fmt.Errorf("pulsar cluster %s is not allowed", pulsarURL)
 		}
 	}
-	if topicFN == "" || pulsarURL == "" {
-		return "", "", "", fmt.Errorf("missing required token or topic or pulsarURL")
-	}
 	return token, topicFN, pulsarURL, nil
-
 }
 
-// ConsumerHeader returns a configuration parameters for Pulsar consumer
-func ConsumerHeader(h *http.Header) (subName string, subInitPos pulsar.SubscriptionInitialPosition, subType pulsar.SubscriptionType, err error) {
-
-	subType, err = model.GetSubscriptionType(h.Get("SubscriptionType"))
-	if err != nil {
-		return "", -1, -1, err
+// BuildTopicFn builds topic fullname.
+func BuildTopicFn(persistent, tenant, namespace, topic string) (string, error) {
+	if persistent == "persistent" || persistent == "p" {
+		return "persistent://" + tenant + "/" + namespace + "/" + topic, nil
+	} else if persistent == "non-persistent" || persistent == "np" {
+		return "non-persistent://" + tenant + "/" + namespace + "/" + topic, nil
+	} else {
+		return "", fmt.Errorf("supported persistent types are persistent, p, non-persistent, np")
 	}
-	subInitPos, err = model.GetInitialPosition(h.Get("SubscriptionInitialPosition"))
-	if err != nil {
-		return "", -1, -1, err
-	}
-
-	subName = h.Get("SubscriptionName")
-	if len(subName) == 0 {
-		name, err := NewUUID()
-		if err != nil {
-			return "", -1, -1, fmt.Errorf("failed to generate uuid error %v", err)
-		}
-		return model.NonResumable + name, subInitPos, subType, nil
-	} else if len(subName) < 5 {
-		return "", -1, -1, fmt.Errorf("subscription name must be more than 4 characters")
-	}
-	return subName, subInitPos, subType, nil
-}
-
-// ClientConsumerHeader returns configuration parameters required to generate Pulsar Client and Consumer
-func ClientConsumerHeader(allowedClusters []string, h *http.Header) (token, topicFN, pulsarURL, subName string, subInitPos pulsar.SubscriptionInitialPosition, subType pulsar.SubscriptionType, err error) {
-	token, topicFN, pulsarURL, err = ReceiverHeader(allowedClusters, h)
-	if err != nil {
-		return "", "", "", "", -1, -1, err
-	}
-
-	subName, subInitPos, subType, err = ConsumerHeader(h)
-	if err != nil {
-		return "", "", "", "", -1, -1, err
-	}
-
-	return token, topicFN, pulsarURL, subName, subInitPos, subType, nil
 }
 
 // AssignString returns the first non-empty string
@@ -164,4 +130,12 @@ func StringToBool(str string) bool {
 	}
 
 	return false
+}
+
+// QueryParamString get URL query parameter with a default value
+func QueryParamString(params url.Values, name, defaultValue string) string {
+	if str, ok := params[name]; ok {
+		return str[0]
+	}
+	return defaultValue
 }

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -68,7 +68,10 @@ func ReceiverHeader(allowedClusters []string, h *http.Header) (token, topicFN, p
 		} else if !StrContains(allowedClusters, pulsarURL) {
 			return "", "", "", fmt.Errorf("pulsar cluster %s is not allowed", pulsarURL)
 		}
+	} else if pulsarURL == "" {
+		return "", "", "", fmt.Errorf("missing configured Pulsar URL")
 	}
+	fmt.Printf("pulsarURL is %s\n", pulsarURL)
 	return token, topicFN, pulsarURL, nil
 }
 


### PR DESCRIPTION
This is a V2 firehose and sse route support.
- Topic full name can be specified in the route
- Only JWT and optional Pulsar URL in the HTTP header

Every SSE is stamped with Pulsar message Id.