### PR TITLE
fix high cpu usage with new ticker in each for loop

### DIFF
--- a/config/pulsar_beam.yml
+++ b/config/pulsar_beam.yml
@@ -1,7 +1,7 @@
 ---
 PORT: 8085
 CLUSTER: localhost
-PbDbType: mongo
+PbDbType: inmemory
 PulsarPublicKey: ./unit-test/example_public_key.pub
 PulsarPrivateKey: ./unit-test/example_private_key
 PbDbInterval: 10s

--- a/src/util/cert-loader.go
+++ b/src/util/cert-loader.go
@@ -42,9 +42,10 @@ func watchFile(filePath string, updated chan *updatedChann) error {
 		return err
 	}
 
+	ticker := time.NewTicker(1 * time.Second)
 	for {
 		select {
-		case <-time.Tick(1 * time.Second):
+		case <-ticker.C:
 			stat, err := os.Stat(filePath)
 			if err == nil {
 				if stat.Size() != initialStat.Size() || stat.ModTime() != initialStat.ModTime() {

--- a/src/util/ttlcache.go
+++ b/src/util/ttlcache.go
@@ -57,9 +57,10 @@ func (c *Cache) Get(key string) (interface{}, bool) {
 
 // eventLoop name is a disguise. I should convert the lock/unlock to an event loop
 func (c *Cache) eventLoop() {
+	ticker := time.NewTicker(c.opt.CleanInterval)
 	for {
 		select {
-		case <-time.Tick(c.opt.CleanInterval):
+		case <-ticker.C:
 			// RLock is faster than Lock, performant improve to get a slice of keys first
 			c.mutex.RLock()
 			keys := make([]string, 0, len(c.items))


### PR DESCRIPTION
A new ticker should be only created outside of for-select loop. The problem is described at
https://forum.golangbridge.org/t/runtime-siftdowntimer-consuming-60-of-the-cpu/3773

There were so many tickers generating runtime.siftdownTimer, runtime.walltime, and runtime.nanotime calls, which hogs CPU